### PR TITLE
increase maxConnections from one to six

### DIFF
--- a/src/ConnectionManager.js
+++ b/src/ConnectionManager.js
@@ -13,7 +13,7 @@ export default class ConnectionManager {
    *
    * @param {int} maxConnections – max open connections
    */
-  constructor(maxConnections = 1) {
+  constructor(maxConnections = 6) {
     /**
      * Private Context
      *


### PR DESCRIPTION
This commit changes the default value from one to six as six
is a more sane default value, even if it could be too much in
certain legacy browsers.