### PR TITLE
 chore(ConnectionManager): merge force and enqueue method for easier use

### DIFF
--- a/src/ConnectionManager.js
+++ b/src/ConnectionManager.js
@@ -55,28 +55,17 @@ export default class ConnectionManager {
           return;
         }
 
-<<<<<<< HEAD
         const item = context.waitingList.first();
-=======
-        const item = context.waitingConnections.first();
->>>>>>> refactor(ConnectionQueue): make queue only deal with queueItems
 
         if (item.connection.state === AbstractConnection.INIT) {
           item.connection.open();
         }
 
         if (item.connection.state === AbstractConnection.OPEN) {
-<<<<<<< HEAD
           context.openList = context.openList.enqueue(item);
         }
 
         context.waitingList = context.waitingList.shift(item);
-=======
-          context.openConnections = context.openConnections.enqueue(item);
-        }
-
-        context.waitingConnections = context.waitingConnections.shift(item);
->>>>>>> refactor(ConnectionQueue): make queue only deal with queueItems
 
         context.next();
       },
@@ -106,11 +95,30 @@ export default class ConnectionManager {
        */
       handleConnectionError: event => {
         this.dequeue(event.target);
+      },
+
+      /**
+       * Closes low prio connections until a slot is free
+       *
+       * @param {int} threshold
+       * @return {bool} - true if there is a free slot, false if not.
+       */
+      closeConnections(threshold) {
+        let item = this.openList.last();
+        while (
+          this.openList.size >= maxConnections - 1 &&
+          item.priority < threshold
+        ) {
+          this.instance.dequeue(item.connection);
+          item = this.openList.last();
+        }
+        return this.openList.size <= maxConnections - 1;
       }
     };
 
     this.enqueue = this.enqueue.bind(context);
     this.dequeue = this.dequeue.bind(context);
+    this.force = this.force.bind(context);
   }
 
   /**
@@ -127,12 +135,21 @@ export default class ConnectionManager {
     }
     const item = new ConnectionQueueItem(connection, priority);
 
+    // default case: connection is initialized, but not yet started
     if (connection.state === AbstractConnection.INIT) {
       this.waitingList = this.waitingList.enqueue(item);
     }
 
+    // theoreticly it is possible to open connections on your own
+    // and then add them to the manager, if this happens we have
+    // to deal with them correctly
     if (connection.state === AbstractConnection.OPEN) {
-      this.openList = this.openList.enqueue(item);
+      if (this.closeConnections(item.priority)) {
+        this.openList = this.openList.enqueue(item);
+      } else {
+        connection.abort();
+        return false;
+      }
     }
 
     connection.addListener(ConnectionEvent.ABORT, this.handleConnectionAbort);
@@ -159,13 +176,8 @@ export default class ConnectionManager {
   dequeue(connection) {
     const item = new ConnectionQueueItem(connection);
 
-<<<<<<< HEAD
     this.waitingList = this.waitingList.dequeue(item);
     this.openList = this.openList.dequeue(item);
-=======
-    this.waitingConnections = this.waitingConnections.dequeue(item);
-    this.openConnections = this.openConnections.dequeue(item);
->>>>>>> refactor(ConnectionQueue): make queue only deal with queueItems
 
     connection.removeListener(
       ConnectionEvent.ABORT,
@@ -185,5 +197,27 @@ export default class ConnectionManager {
     }
 
     this.next();
+  }
+
+  /**
+   * Immediatly opens a given connection, cancels other connections if needed
+   *
+   * @this ConnectionManager~Context
+   * @param {AbstractConnection} connection
+   */
+  force(connection) {
+    const item = new ConnectionQueueItem(connection, Number.MAX_SAFE_INTEGER);
+
+    if (!this.closeConnections(item.priority)) {
+      return false;
+    }
+
+    if (item.connection.state === AbstractConnection.INIT) {
+      item.connection.open();
+    }
+
+    if (item.connection.state === AbstractConnection.OPEN) {
+      context.openList = context.openList.enqueue(item);
+    }
   }
 }

--- a/src/ConnectionManager.js
+++ b/src/ConnectionManager.js
@@ -55,17 +55,28 @@ export default class ConnectionManager {
           return;
         }
 
+<<<<<<< HEAD
         const item = context.waitingList.first();
+=======
+        const item = context.waitingConnections.first();
+>>>>>>> refactor(ConnectionQueue): make queue only deal with queueItems
 
         if (item.connection.state === AbstractConnection.INIT) {
           item.connection.open();
         }
 
         if (item.connection.state === AbstractConnection.OPEN) {
+<<<<<<< HEAD
           context.openList = context.openList.enqueue(item);
         }
 
         context.waitingList = context.waitingList.shift(item);
+=======
+          context.openConnections = context.openConnections.enqueue(item);
+        }
+
+        context.waitingConnections = context.waitingConnections.shift(item);
+>>>>>>> refactor(ConnectionQueue): make queue only deal with queueItems
 
         context.next();
       },
@@ -148,8 +159,13 @@ export default class ConnectionManager {
   dequeue(connection) {
     const item = new ConnectionQueueItem(connection);
 
+<<<<<<< HEAD
     this.waitingList = this.waitingList.dequeue(item);
     this.openList = this.openList.dequeue(item);
+=======
+    this.waitingConnections = this.waitingConnections.dequeue(item);
+    this.openConnections = this.openConnections.dequeue(item);
+>>>>>>> refactor(ConnectionQueue): make queue only deal with queueItems
 
     connection.removeListener(
       ConnectionEvent.ABORT,

--- a/src/ConnectionQueue.js
+++ b/src/ConnectionQueue.js
@@ -42,29 +42,30 @@ export default class ConnectionQueue {
    * @return {AbstractConnection} - first connection
    */
   first() {
-    if (this.connections.first() === undefined) {
-      return undefined;
-    }
-
-    return this.connections.first().connection;
+    return this.connections.first();
+  }
+  /**
+   * returns the last connection
+   * @return {AbstractConnection} - last connection
+   */
+  last() {
+    return this.connections.last();
   }
 
-  /**
-   * returns a new queue without the first connection
-   * @return {ConnectionQueue} – ConnectionQueue without first connection
-   */
   shift() {
     return new ConnectionQueue(this.connections.shift());
   }
 
+  pop() {
+    return new ConnectionQueue(this.connections.pop());
+  }
+
   /**
    * Adds given connection to queue
-   * @param {AbstractConnection} connection – Connection to be added to queue
-   * @param {Integer} [priority] – priority of connection
+   * @param {ConnectionQueueItem} item – ConnectionQueueItem wich contains connection to be added to queue
    * @return {ConnectionQueue} - ConnectionQueue containing the added connection
    */
-  enqueue(connection, priority) {
-    const item = new ConnectionQueueItem(connection, priority);
+  enqueue(item) {
     const index = this.connections.findIndex(listItem => listItem.equals(item));
     let connections = null;
 
@@ -94,17 +95,13 @@ export default class ConnectionQueue {
    * @param {AbstractConnection} connection – connection to be deleted
    * @return {ConnectionQueue} - ConnectionQueue without the resp. connection
    */
-  dequeue(connection) {
-    const item = new ConnectionQueueItem(connection);
-
+  dequeue(item) {
     return new ConnectionQueue(
       this.connections.filter(listItem => !listItem.equals(item))
     );
   }
 
-  includes(connection) {
-    const item = new ConnectionQueueItem(connection);
-
+  includes(item) {
     return this.connections.some(listItem => listItem.equals(item));
   }
 }

--- a/src/__tests__/ConnectionQueue-test.js
+++ b/src/__tests__/ConnectionQueue-test.js
@@ -8,11 +8,17 @@ describe("ConnectionQueue", () => {
   let connection1 = null;
   let connection2 = null;
   let connection3 = null;
+  let item1 = null;
+  let item2 = null;
+  let item3 = null;
 
   beforeEach(() => {
     connection1 = new AbstractConnection("http://example.com/1");
     connection2 = new AbstractConnection("http://example.com/2");
     connection3 = new AbstractConnection("http://example.com/3");
+    item1 = new ConnectionQueueItem(connection1);
+    item2 = new ConnectionQueueItem(connection2, 2);
+    item3 = new ConnectionQueueItem(connection3, 3);
   });
 
   describe("#init", () => {
@@ -35,49 +41,41 @@ describe("ConnectionQueue", () => {
 
   describe("#enqueue", () => {
     it("enqueues correctly (first)", () => {
-      const connection = new AbstractConnection("http://example.com");
-      const queue = new ConnectionQueue().enqueue(connection);
+      const queue = new ConnectionQueue().enqueue(item1);
 
-      expect(queue.first()).toEqual(connection);
+      expect(queue.first()).toEqual(item1);
     });
 
     it("enqueues correctly (size)", () => {
-      const connection = new AbstractConnection("http://example.com");
-      const queue = new ConnectionQueue().enqueue(connection);
+      const queue = new ConnectionQueue().enqueue(item1);
 
       expect(queue.size).toEqual(1);
     });
 
     it("sorts connections by priority", () => {
-      const queue = new ConnectionQueue()
-        .enqueue(connection1, 1)
-        .enqueue(connection2, 2);
+      const queue = new ConnectionQueue().enqueue(item2).enqueue(item3);
 
-      expect(queue.first()).toEqual(connection2);
+      expect(queue.first()).toEqual(item2);
     });
   });
 
   describe("#dequeue", () => {
     describe("with existing connection", function() {
       it("dequeues correctly (first)", () => {
-        const queue = new ConnectionQueue()
-          .enqueue(connection1)
-          .dequeue(connection1);
+        const queue = new ConnectionQueue().enqueue(item1).dequeue(item1);
 
         expect(queue.first()).toBe(undefined);
       });
 
       it("dequeues correctly (size)", () => {
-        const queue = new ConnectionQueue()
-          .enqueue(connection1)
-          .dequeue(connection1);
+        const queue = new ConnectionQueue().enqueue(item1).dequeue(item1);
 
         expect(queue.size).toEqual(0);
       });
     });
     describe("with connection that doesn't exist", function() {
       it("doesn't do anything", () => {
-        expect(() => new ConnectionQueue().dequeue(connection1)).not.toThrow();
+        expect(() => new ConnectionQueue().dequeue(item1)).not.toThrow();
       });
     });
   });
@@ -85,11 +83,12 @@ describe("ConnectionQueue", () => {
   describe("#first", function() {
     it("returns first item of queue", function() {
       const queue = new ConnectionQueue()
-        .enqueue(connection1, 1)
-        .enqueue(connection2, 2)
-        .enqueue(connection3, 3);
+        .enqueue(item1)
+        .enqueue(item2)
+        .enqueue(item3);
+      const first = queue.first();
 
-      expect(queue.first()).toBe(connection3);
+      expect(first.equals(item3)).toBe(true);
     });
     it("returns undefined when calling first on empty queue", function() {
       const queue = new ConnectionQueue();
@@ -100,35 +99,28 @@ describe("ConnectionQueue", () => {
 
   describe("#shift", function() {
     it("returns a new queue without the first element", function() {
-      const queue = new ConnectionQueue()
-        .enqueue(connection1, 1)
-        .enqueue(connection2, 2)
-        .enqueue(connection3, 3)
-        .shift();
+      let queue = new ConnectionQueue()
+        .enqueue(item1)
+        .enqueue(item2)
+        .enqueue(item3);
+      queue = queue.dequeue(queue.first());
 
-      expect(queue.includes(connection3)).toEqual(false);
-    });
-    it("returns empty queue when shift() on empty queue", function() {
-      const queue = new ConnectionQueue().shift();
-
-      expect(queue.size).toEqual(0);
+      expect(queue.includes(item3)).toEqual(false);
     });
   });
 
   describe("#includes", () => {
     describe("with existing connection", function() {
       it("dequeues correctly (size)", () => {
-        const queue = new ConnectionQueue().enqueue(connection1);
+        const queue = new ConnectionQueue().enqueue(item1);
 
-        expect(
-          queue.connections.includes(new ConnectionQueueItem(connection1))
-        ).toEqual(true);
+        expect(queue.connections.includes(item1)).toEqual(true);
       });
     });
 
     describe("with connection that doesn't exist", function() {
       it("doesn't do anything", () => {
-        expect(new ConnectionQueue().includes(connection1)).toEqual(false);
+        expect(new ConnectionQueue().includes(item1)).toEqual(false);
       });
     });
   });


### PR DESCRIPTION
In this PR I have merged the `force` & `enqueue` methods for easier use. this also makes the whole `enqueue` methods and `next` calls less complicated.