### PR TITLE
fix: track connections as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
     "babel-jest": "^21.2.0",
     "babel-preset-env": "^1.6.1",
     "jest": "^21.2.1",
-    "jest-cli": "^21.2.1"
+    "jest-cli": "^21.2.1",
+    "@dcos/connections": "^0.4.0"
   },
   "dependencies": {
-    "@dcos/connections": "0.4.0",
     "immutable": "^3.8.2"
+  },
+  "peerDependencies": {
+    "@dcos/connections": "^0.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@dcos/connections@0.4.0":
+"@dcos/connections@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@dcos/connections/-/connections-0.4.0.tgz#89471c657e2b73184be3e1c4ebfc7eff55f44de9"
   integrity sha512-Ldc1KpH8YnZdQueljQSB06lVp7fEWhThGkMLS/y9ecJLPklhCRWDOzhf3H43qpIgg8QBIoRTspzNMCWBa0dmcg==


### PR DESCRIPTION
Adjust `package.json` to track `@dcos/connections`  as peer dependency this enables custom connection type and resolves type conflicts that prevent connection scheduling as `AbstractConnection.INIT` symbols don't match.

BREAKING CHANGE: The  `@dcos/connections` package is now tracked as peer dependency which requires an additional installation step. Run `npm install @dcos/connections dcos/connection-manager` or `yarn add @dcos/connections dcos/connection-manager` to install the connection manager and connections package.